### PR TITLE
Change trailing metadata delimiter

### DIFF
--- a/src/notesdir/accessors/markdown.py
+++ b/src/notesdir/accessors/markdown.py
@@ -99,8 +99,9 @@ class MarkdownAccessor(Accessor):
        keywords:
        - boring
        - unnecessary
-       ...
-       The three dots indicate the end of the metadata. Now we're in **Markdown**!
+       ---
+
+       The three hyphens indicate the end of the metadata. Now we're in **Markdown**!
        This is a really #uninteresting note.
     """
     def _load(self):
@@ -126,7 +127,8 @@ class MarkdownAccessor(Accessor):
         if self.meta:
             sio = StringIO()
             yaml.safe_dump(self.meta, sio)
-            text = f'---\n{sio.getvalue()}...\n{body}'
+            # include a blank line between metadata and body
+            text = f'---\n{sio.getvalue()}---\n\n{body}'
         else:
             text = body
         with open(self.path, 'w') as file:

--- a/tests/repos/test_direct.py
+++ b/tests/repos/test_direct.py
@@ -51,7 +51,7 @@ def test_change(fs):
     repo = DirectRepoConf(root_paths={'/notes'}).instantiate()
     repo.change(edits)
     assert not Path('/notes/one.md').exists()
-    assert Path('/notes/moved.md').read_text() == '---\ntitle: New Title\n...\n[1](new)'
+    assert Path('/notes/moved.md').read_text() == '---\ntitle: New Title\n---\n\n[1](new)'
     assert Path('/notes/two.md').read_text() == '[2](bar)'
 
 

--- a/tests/repos/test_sqlite.py
+++ b/tests/repos/test_sqlite.py
@@ -114,7 +114,7 @@ def test_change(fs):
     repo = config().instantiate()
     repo.change(edits)
     assert not Path(path1).exists()
-    assert Path(path3).read_text() == '---\ntitle: New Title\n...\n[1](new)'
+    assert Path(path3).read_text() == '---\ntitle: New Title\n---\n\n[1](new)'
     assert Path(path2).read_text() == '[2](bar)'
     assert repo.info(path1, FileInfoReq.full()) == FileInfo(path1)
     assert repo.info(path3, FileInfoReq.full()) == FileInfo(path3, title='New Title', links=[LinkInfo(path3, 'new')])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -357,7 +357,8 @@ keywords:
 - tag1
 - tag2
 title: A Bland Note
-...
+---
+
 some text"""
     assert cli.main(['change', '-d', 'tag1', '-t', 'A Better Note', 'foo.md']) == 0
     assert Path('/notes/cwd/foo.md').read_text() == """---
@@ -365,7 +366,8 @@ created: 2012-02-03 00:00:00
 keywords:
 - tag2
 title: A Better Note
-...
+---
+
 some text"""
 
 
@@ -445,10 +447,12 @@ def test_backfill(fs, capsys):
 title: Good Note
 created: 2001-02-03T04:05:06-07:00
 ...
+
 Hi!"""
     no_title_doc = """---
 created: 2002-03-04T05:06:07-08:00
 ...
+
 Hello!"""
     no_created_doc = """---
 title: Mediocre Note
@@ -485,16 +489,19 @@ Whatever"""
     assert Path(no_title_path).read_text() == """---
 created: 2002-03-04 05:06:07-08:00
 title: no-title
-...
+---
+
 Hello!"""
     assert Path(no_created_path).read_text() == """---
 created: 2010-09-08 07:06:05+00:00
 title: Mediocre Note
-...
+---
+
 Whatever"""
     assert Path(nothing_path).read_text() == """---
 created: 2010-09-08 07:06:05+00:00
 title: nothing
-...
+---
+
 Boo."""
     assert Path(unsupported_path).read_text() == unsupported_doc


### PR DESCRIPTION
MarkdownAccessor accepts either "..." or "---" as the trailing delimiter
for metadata according to the Pandoc convention for metadata blocks.
However, the defacto standard is to use "---" for both delimiters.

This changes the trailing delimiter to "---" on output, while
still accepting both formats on input, to improve interoperability
with software that only accepts "---".

It also introduces the convention that the trailing delimiter
will be followed by a blank line.